### PR TITLE
Add async thunk fetch for posts

### DIFF
--- a/src/api/server.js
+++ b/src/api/server.js
@@ -65,7 +65,7 @@ const notificationTemplates = [
 new Server({
   routes() {
     this.namespace = 'fakeApi'
-    //this.timing = 2000
+    this.timing = 2000
 
     this.resource('users')
     this.resource('posts')

--- a/src/features/posts/EditPostForm.js
+++ b/src/features/posts/EditPostForm.js
@@ -2,13 +2,12 @@ import React, { useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useHistory } from 'react-router-dom'
 
-import { postUpdated } from './postsSlice'
+import { postUpdated, selectPostById } from './postsSlice'
 
 export const EditPostForm = ({ match }) => {
     const { postId } = match.params
-    const post = useSelector((state) =>
-          state.posts.find((post) => post.id === postId)
-    )
+    const post = useSelector(state => selectPostById(state, postId))
+    
     const [title, setTitle] = useState(post.title)
     const [content, setContent] = useState(post.content)
 

--- a/src/features/posts/PostsList.js
+++ b/src/features/posts/PostsList.js
@@ -1,40 +1,64 @@
-import React from 'react'
-import { useSelector } from 'react-redux'
+import React, { useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
 import { Link } from 'react-router-dom'
 
 import { PostAuthor } from './PostAuthor'
 import { TimeAgo } from './TimeAgo'
 import { ReactionButtons } from './ReactionButtons'
 
+import { selectAllPosts, fetchPosts } from './postsSlice'
+
+const PostExcerpt = ({ post }) => {
+  return (
+    <article className="post-excerpt" key={post.id}>
+      <h3>{post.title}</h3>
+      <div>
+        <PostAuthor userId={post.user} />
+        <TimeAgo timestamp={post.date} />
+      </div>
+      <p className="post-content">{post.content.substring(0, 100)}</p>
+
+      <ReactionButtons post={post} />
+      <Link to={`/posts/${post.id}`} className="button muted-button">
+        View Post
+      </Link>
+    </article>
+  )
+}
+
 export const PostsList = () => {
-    const posts = useSelector((state) => state.posts)
+    const dispatch = useDispatch()
+    const posts = useSelector(selectAllPosts)
 
-    // Sort posts in reverse chronological order by datetime string
-    const orderedPosts = posts
-      .slice()
-      .sort((a, b) => b.date.localeCompare(a.date))
+    const postStatus = useSelector(state => state.posts.status)
+    const error = useSelector(state => state.posts.error)
 
-    const renderedPosts = orderedPosts.map((post) => {
-      return (
-        <article className="post-excerpt" key={post.id}>
-            <h3>{post.title}</h3>
-            <div>
-              <PostAuthor userId={post.user} />
-              <TimeAgo timestamp={post.date} />
-            </div>
-            <p className="post-content">{post.content.substring(0, 100)}</p>
-            <ReactionButtons post={post} />
-            <Link to={`/posts/${post.id}`} className="button muted-button">
-                View Post
-            </Link>
-        </article>
-      )
-    })
+    useEffect(() => {
+      if (postStatus === 'idle') {
+        dispatch(fetchPosts())
+      }
+    }, [postStatus, dispatch])
+
+    let content
+
+    if (postStatus === 'loading') {
+      content = <div className="loader">Loading...</div>
+    } else if (postStatus === 'succeeded') {
+      // Sort posts in reverse chronological order by datetime string
+      const orderedPosts = posts
+        .slice()
+        .sort((a, b) => b.date.localeCompare(a.date))
+      content = orderedPosts.map(post => (
+        <PostExcerpt key={post.id} post={post} />
+      ))
+    } else if (postStatus === 'failed') {
+      content = <div>{error}</div>
+    }
 
     return (
         <section className="posts-list">
             <h2>Posts</h2>
-            {renderedPosts}
+            {content}
         </section>
     )
 }

--- a/src/features/posts/SinglePostPage.js
+++ b/src/features/posts/SinglePostPage.js
@@ -6,12 +6,12 @@ import { PostAuthor } from './PostAuthor'
 import { TimeAgo } from './TimeAgo'
 import { ReactionButtons } from './ReactionButtons'
 
+import { selectPostById } from './postsSlice'
+
 export const SinglePostPage = ({ match }) => {
     const { postId } = match.params
 
-    const post = useSelector((state) =>
-        state.posts.find((post) => post.id === postId)
-    )
+    const post = useSelector(state => selectPostById(state, postId))
 
     if (!post) {
         return (

--- a/src/features/posts/postsSlice.js
+++ b/src/features/posts/postsSlice.js
@@ -1,36 +1,16 @@
-import { createSlice, nanoid } from '@reduxjs/toolkit'
-import { sub } from 'date-fns'
+import { createSlice, nanoid, createAsyncThunk } from '@reduxjs/toolkit'
+import { client } from '../../api/client'
 
-const initialState = [
-  {
-    id: '1',
-    title: 'First Post!',
-    content: 'Hello!',
-    user: '0',
-    date: sub(new Date(), { minutes: 10 }).toISOString(),
-    reactions: {
-      thumbsUp: 0,
-      hooray: 0,
-      heart: 0,
-      rocket: 0,
-      eyes: 0,
-    },
-  },
-  {
-    id: '2',
-    title: 'Second Post',
-    content: 'More text',
-    user: '2',
-    date: sub(new Date(), { minutes: 5 }).toISOString(),
-    reactions: {
-      thumbsUp: 0,
-      hooray: 0,
-      heart: 0,
-      rocket: 0,
-      eyes: 0,
-    },
-  },
-]
+const initialState = {
+    posts: [],
+    status: 'idle',
+    error: null
+}
+
+export const fetchPosts = createAsyncThunk('posts/fetchPosts', async () => {
+    const response = await client.get('/fakeApi/posts')
+    return response.posts
+})
 
 const postsSlice = createSlice({
     name: 'posts',
@@ -38,7 +18,7 @@ const postsSlice = createSlice({
     reducers: {
         postAdded: {
             reducer(state, action) {
-                state.push(action.payload)
+                state.posts.push(action.payload)
             },
             prepare(title, content, userId) {
                 return {
@@ -61,22 +41,40 @@ const postsSlice = createSlice({
         },
         reactionAdded(state, action) {
             const { postId, reaction } = action.payload
-            const existingPost = state.find((post) => post.id === postId)
+            const existingPost = state.posts.find((post) => post.id === postId)
             if (existingPost) {
                 existingPost.reactions[reaction]++
             }
         },
         postUpdated(state, action) {
             const { id, title, content } = action.payload
-            const existingPost = state.find((post) => post.id === id)
+            const existingPost = state.posts.find((post) => post.id === id)
             if (existingPost) {
                 existingPost.title = title
                 existingPost.content = content
             }
         },
     },
+    extraReducers: {
+        [fetchPosts.pending]: (state, action) => {
+            state.status = 'loading'
+        },
+        [fetchPosts.fulfilled]: (state, action) => {
+            state.status = 'succeeded'
+            // Add any fetched posts to the array
+            state.posts = state.posts.concat(action.payload)
+        },
+        [fetchPosts.rejected]: (state, action) => {
+            state.status = 'failed'
+            state.error = action.error.message
+        }
+    }
 })
 
 export const { postAdded, postUpdated, reactionAdded } = postsSlice.actions
 
 export default postsSlice.reducer
+
+export const selectAllPosts = state => state.posts.posts
+
+export const selectPostById = (state, postId) => state.posts.posts.find(post => post.id === postId)


### PR DESCRIPTION
Part of Redux tutorial Step 5 
https://redux.js.org/tutorials/essentials/part-5-async-logic

Extra Reducers seems to be the best strategy for async calls.

In _postList.js_, we call below so that it'll run this effect if postStatus or dispatch changes. Otherwise, it runs it once after it renders ([reference](https://reactjs.org/docs/hooks-effect.html))

```
useEffect(() => {
      if (postStatus === 'idle') {
        dispatch(fetchPosts())
      }
    }, [postStatus, dispatch])

```

The three extraReducers status (pending, fulfilled, and rejected) are types determined by `createAsyncThunk` when used with `fetchPost`
https://redux-toolkit.js.org/api/createAsyncThunk#type
```
extraReducers: {
        [fetchPosts.pending]: (state, action) => {
            state.status = 'loading'
        },
        [fetchPosts.fulfilled]: (state, action) => {
            state.status = 'succeeded'
            // Add any fetched posts to the array
            state.posts = state.posts.concat(action.payload)
        },
        [fetchPosts.rejected]: (state, action) => {
            state.status = 'failed'
            state.error = action.error.message
        }
    }
```